### PR TITLE
Add simple preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,19 @@ that VS Code provides. With live preview enabled, final look-and-feel is just on
   - `ctrl+shift+r`      Preview
   - `ctrl+k r`          Preview to Side
 
->**Notice:** The preview feature requires Python to be installed. The `sphinx` Python module is also required. 
-check out the [steps to configure sphinx](docs/sphinx.md).
+>**Notice:** The preview feature requires [Sphinx](http://www.sphinx-doc.org/) to be installed, which also requires Python.
+Check out the [steps to configure sphinx](docs/sphinx.md).
+
+You can also configure a simple preview using a reStructuredText to HTML renderer, like rst2html from [Docutils](http://docutils.sourceforge.net). **The `renderTool` option will disable Sphinx build if set.**
+You can install Docutils with: `pip install docutils`. (required Python and Python-PIP installed)
+
+```json
+{
+    "restructuredtext.renderTool": "rst2html5.py",
+    "restructuredtext.renderFlags": ["--halt=5"]
+}
+```
+
 
 ## How to install from Marketplace
 

--- a/package.json
+++ b/package.json
@@ -141,6 +141,19 @@
           "default": ".",
           "description": "The folder that contains makefile and make.bat relative to workspace root."
         },
+        "restructuredtext.renderTool": {
+          "type": "string",
+          "default": "",
+          "description": "Tool used to render HTML preview (e.g. 'rst2html5')"
+        },
+        "restructuredtext.renderFlags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Flags used by render tool (e.g. ['--halt=5'])"
+        },
         "restructuredtext.updateOnTextChanged": {
           "type": "string",
           "default": "true",


### PR DESCRIPTION
Add an option to configure a simple reStructuredText renderer to make it easier to set up and preview files. In this option it will consume the tool's stdout.