### PR TITLE
Add new command to underline current line.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,18 @@
 			"args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
 			"sourceMaps": true,
 			"outFiles": ["${workspaceRoot}/out/extension.js"]
-		}
+		},
+        {
+            "name": "Launch Tests",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/out/test" ],
+            "stopOnEntry": false,
+            "sourceMaps": true,
+            "outFiles": [ "${workspaceRoot}/out/test/**/*.js" ],
+            "preLaunchTask": "npm"
+        }
+
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,10 @@
+{
+    "version": "0.1.0",
+
+    "command": "npm",
+    "isShellCommand": true,
+    "showOutput": "silent",
+    "args": ["run", "compile", "--loglevel", "silent"],
+    "isBackground": true,
+    "problemMatcher": "$tsc-watch"
+}

--- a/package.json
+++ b/package.json
@@ -8,9 +8,12 @@
     "vscode": "^1.9.0"
   },
   "devDependencies": {
-    "vscode": "^1.0.3",
+    "@types/mocha": "^2.2.43",
+    "@types/node": "^7.0.5",
+    "mocha": "^4.0.1",
+    "ts-node": "^3.3.0",
     "typescript": "^2.1.5",
-    "@types/node": "^7.0.5"
+    "vscode": "^1.0.3"
   },
   "license": "SEE LICENSE IN LICENSE.txt",
   "homepage": "https://github.com/vscode-restructuredtext/vscode-restructuredtext/blob/master/README.md",
@@ -34,6 +37,7 @@
     "onCommand:restructuredtext.showPreview",
     "onCommand:restructuredtext.showPreviewToSide",
     "onCommand:restructuredtext.showSource",
+    "onCommand:restructuredtext.features.underline.underline",
     "onLanguage:restructuredtext"
   ],
   "contributes": {
@@ -78,6 +82,12 @@
         "command": "restructuredtext.showPreviewToSide",
         "key": "ctrl+k r",
         "mac": "cmd+k r",
+        "when": "editorTextFocus"
+      },
+      {
+        "command": "restructuredtext.features.underline.underline",
+        "key": "ctrl+=",
+        "mac": "cmd+=",
         "when": "editorTextFocus"
       }
     ],
@@ -197,7 +207,8 @@
   "scripts": {
     "vscode:prepublish": "tsc -p ./",
     "compile": "tsc -watch -p ./",
-    "postinstall": "node ./node_modules/vscode/bin/install"
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "vstest": "node ./node_modules/vscode/bin/test"
   },
   "dependencies": {
     "file-url": "^1.0.1"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import {
 } from "vscode";
 import RstLintingProvider from './features/rstLinter';
 import RstDocumentContentProvider from './features/rstDocumentContent';
+import { underline } from './features/underline';
 import * as path from "path";
 
 export function activate(context: ExtensionContext) {
@@ -18,6 +19,9 @@ export function activate(context: ExtensionContext) {
     let d3 = commands.registerCommand("restructuredtext.showSource", showSource);
 
     context.subscriptions.push(d1, d2, d3, registration);
+    context.subscriptions.push(
+        commands.registerTextEditorCommand('restructuredtext.features.underline.underline', underline)
+    );
 
     let linter = new RstLintingProvider();
     linter.activate(context.subscriptions);

--- a/src/features/underline.ts
+++ b/src/features/underline.ts
@@ -1,0 +1,74 @@
+/**
+ * This module provides utility functions to handle underline title levels
+ */
+import * as vscode from 'vscode';
+
+
+// list of underline characters, from higher level to lower level
+const underlineChars = ['=', '-', '~', '+'];
+
+
+/**
+ * Analyze current underline char and return the underline character corresponding
+ * to the next subtitle level.
+ *
+ * @param current - The current underline character
+ * @return - The next underline char in the list of precedence
+ */
+export function nextUnderlineChar(current: string): string {
+    const nextCharIndex = (underlineChars.indexOf(current) + 1) % underlineChars.length;
+    return underlineChars[nextCharIndex];
+}
+
+/**
+ * Check if current line is followed by a line of underline characters. If true, return
+ * the underline character, otherwise return null.
+ *
+ * @param currentLine - current line of text under cursor
+ * @param nextLine - next line of text
+ * @return - the current underline character if any or null
+ */
+export function currentUnderlineChar(currentLine: string, nextLine: string): string {
+    for (const char of underlineChars) {
+        if (nextLine.length >= currentLine.length && nextLine === char.repeat(nextLine.length)) {
+            return char;
+        }
+    }
+    return null;
+}
+
+
+/**
+ * Underline current line. If it's already underlined, pick up the underline character
+ * corresponding to the next subtitle level and replace the current underline.
+ */
+export function underline(textEditor: vscode.TextEditor, edit: vscode.TextEditorEdit, args: any[]) {
+    textEditor.selections.forEach(selection => {
+        const position = selection.active;
+        const line = textEditor.document.lineAt(position.line).text;
+        if (line === '') {
+            return; // don't underline empty lines
+        }
+        let underlineChar = null;
+        let nextLine = null;
+        if (position.line < textEditor.document.lineCount - 1) {
+            nextLine = textEditor.document.lineAt(position.line + 1).text;
+            underlineChar = currentUnderlineChar(line, nextLine);
+        }
+        if (underlineChar === null) {
+            edit.insert(
+                new vscode.Position(position.line, line.length),
+                '\n' + '='.repeat(line.length)
+            );
+        } else {
+            const nextLineRange = new vscode.Range(
+                new vscode.Position(position.line + 1, 0),
+                new vscode.Position(position.line + 1, nextLine.length)
+            );
+            edit.replace(
+                nextLineRange,
+                nextUnderlineChar(underlineChar).repeat(line.length)
+            );
+        }
+    });
+}

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1,0 +1,50 @@
+import * as assert from "assert";
+
+import * as vscode from "vscode";
+import * as underline from "../src/features/underline";
+
+
+suite("reStructuredText tests", () => {
+    test("editor underlines title", done => {
+        let textEditor: vscode.TextEditor;
+        let textDocument: vscode.TextDocument;
+        vscode.workspace.openTextDocument({ content: 'hello', language: 'reStructuredText' }).then(document => {
+            textDocument = document;
+            return vscode.window.showTextDocument(textDocument);
+        }).then(editor => {
+            let textEditor = editor;
+            const newpos = new vscode.Position(0, 5);
+            editor.selection = new vscode.Selection(newpos, newpos);
+            return editor.edit(edit => {
+                underline.underline(editor, edit, null);
+            });
+        }).then(() => {
+            assert.equal(textDocument.getText(), 'hello\n=====');
+        }).then(done, done);
+    });
+
+    test("editor toggles title level", done => {
+        let textEditor: vscode.TextEditor;
+        let textDocument: vscode.TextDocument;
+        vscode.workspace.openTextDocument({ content: 'hello\n=====', language: 'reStructuredText' }).then(document => {
+            textDocument = document;
+            return vscode.window.showTextDocument(textDocument);
+        }).then(editor => {
+            let textEditor = editor;
+            const newpos = new vscode.Position(0, 5);
+            editor.selection = new vscode.Selection(newpos, newpos);
+            return editor.edit(edit => {
+                underline.underline(editor, edit, null);
+            });
+        }).then(() => {
+            assert.equal(textDocument.getText(), 'hello\n-----');
+        }).then(done, done);
+    });
+
+    test("nextLineChar", () => {
+        assert.equal(underline.nextUnderlineChar('='), '-');
+        assert.equal(underline.nextUnderlineChar('-'), '~');
+        assert.equal(underline.nextUnderlineChar('~'), '+');
+        assert.equal(underline.nextUnderlineChar('+'), '=');
+    });
+});

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,22 @@
+//
+// PLEASE DO NOT MODIFY / DELETE UNLESS YOU KNOW WHAT YOU ARE DOING
+//
+// This file is providing the test runner to use when running extension tests.
+// By default the test runner in use is Mocha based.
+//
+// You can provide your own test runner if you want to override it by exporting
+// a function run(testRoot: string, clb: (error:Error) => void) that the extension
+// host can call to run the tests. The test runner is expected to use console.log
+// to report the results back to the caller. When the tests are finished, return
+// a possible error to the callback or null if none.
+
+var testRunner = require('vscode/lib/testrunner');
+
+// You can directly control Mocha options by uncommenting the following lines
+// See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
+testRunner.configure({
+    ui: 'tdd', 		// the TDD UI is being used in extension.test.ts (suite, test, etc.)
+    useColors: true // colored output from test results
+});
+
+module.exports = testRunner;


### PR DESCRIPTION
It tries to work as emacs does, by checking if current line is already
underlined or not. If it's not, then insert a new line of '=', otherwise
cycle over underline characters.

Map the command to 'Ctrl+=' and add tests for it.