### PR TITLE
Footnote links can contain `-`

### DIFF
--- a/syntaxes/restructuredtext.tmLanguage
+++ b/syntaxes/restructuredtext.tmLanguage
@@ -586,7 +586,7 @@
 					<key>comment</key>
 					<string>footnote reference [#]_ or [#foo]_</string>
 					<key>match</key>
-					<string>((\[#)[A-z0-9_]*(\]))(_)</string>
+					<string>((\[#)[A-z0-9_\-]*(\]))(_)</string>
 					<key>name</key>
 					<string>meta.link.footnote.auto.restructuredtext</string>
 				</dict>


### PR DESCRIPTION
This fixes highlighting of footnote links that contain a `-`.