### PR TITLE
Expand macros in python.pythonPath configuration

### DIFF
--- a/src/features/rstLinter.ts
+++ b/src/features/rstLinter.ts
@@ -2,6 +2,7 @@
 import { workspace, Disposable, Diagnostic, DiagnosticSeverity, Range } from 'vscode';
 
 import { LintingProvider, LinterConfiguration, Linter } from './utils/lintingProvider';
+import RstDocumentContentProvider from './rstDocumentContent';
 
 export default class RstLintingProvider implements Linter {
 
@@ -17,7 +18,7 @@ export default class RstLintingProvider implements Linter {
 		if (!section) return;
 
 		var module: string[] = [];
-		var python = workspace.getConfiguration("python").get<string>("pythonPath", null);
+		var python = RstDocumentContentProvider.loadSetting('pythonPath', null, 'python');
 		var build: string;
 		if (python == null) {
 			build = section.get<string>('linter.executablePath', "restructuredtext-lint");


### PR DESCRIPTION
`${workspaceRoot}` in the `python.pythonPath` configuration is not expanded.
This leaves this error :
`Cannot {filename}. The executable was not found. Use the 'restructuredtext.linter.executablePath' setting to configure the location of the executable`.

This PR simply expands the configuration using `RstDocumentContentProvider.loadSetting`.