### PR TITLE
fixes "Incorrect type. Expected string[]"" warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -248,19 +248,19 @@
           "description": "Whether the linter is run on save or on type or disabled."
         },
         "restructuredtext.linter.extraArgs": {
-          "type": "string[]",
+          "type": "array",
           "default": [],
           "description": "Extra arguments to restructuredtext-lint."
         },
         "restructuredtext.linter.sphinxDirectives": {
-          "type": "string[]",
+          "type": "array",
           "default": [
             "toctree"
           ],
           "description": "Sphinx directives."
         },
         "restructuredtext.linter.sphinxTextRoles": {
-          "type": "string[]",
+          "type": "array",
           "default": [
             "doc",
             "ref"


### PR DESCRIPTION
VS Code recently started giving a warning in the configuration files for these parameters. Using the type as 'array' should solve it.

Just a pet peeve.