### PR TITLE
[Discussion] [Live Share] Restricting language services to local files

### DIFF
--- a/src/rstLsp/extension.ts
+++ b/src/rstLsp/extension.ts
@@ -53,7 +53,10 @@ export function activate(context: vscode.ExtensionContext, channel: vscode.Outpu
         // Options to control the language client
         let clientOptions: LanguageClientOptions = {
             // Register the server for plain text documents
-            documentSelector: ['restructuredtext'],
+            documentSelector: [
+                { language: 'restructuredtext', scheme: 'file' },
+                { language: 'restructuredtext', scheme: 'untitled' }
+            ],
             synchronize: {
                 // Synchronize the setting section 'lspSample' to the server
                 configurationSection: 'restructuredtext',


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for reStructuredText, this PR simply updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has the reStructuredText extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

*Note: As an example, the TypeScript/JavaScript language services that come in-box with VS Code [already have this scheme restriction](https://github.com/Microsoft/vscode/blob/master/extensions/typescript-language-features/src/utils/fileSchemes.ts#L12), and so this PR replicates that behavior.*