### PR TITLE
[Live Share] Limiting linting to local files

### DIFF
--- a/src/features/utils/lintingProvider.ts
+++ b/src/features/utils/lintingProvider.ts
@@ -107,7 +107,10 @@ export class LintingProvider {
 	}
 
 	private triggerLint(textDocument: vscode.TextDocument): void {
-		if (textDocument.languageId !== this.linter.languageId || this.executableNotFound || RunTrigger.from(this.linterConfiguration.runTrigger) === RunTrigger.off){
+		if (textDocument.languageId !== this.linter.languageId || 
+			textDocument.uri.scheme !== "file" ||
+			this.executableNotFound ||
+			RunTrigger.from(this.linterConfiguration.runTrigger) === RunTrigger.off){
 			return;
 		}
 		let key = textDocument.uri.toString();


### PR DESCRIPTION
This is a followup to #86, and simply limits linting to local files. Apologies for not catching this when I sent #86, which was intended to limit all language services to local files.

// CC @lextm 