### PR TITLE
Automatically locate Sphnix conf.py by searching the workspace and allow the user to pick if there are more than one such file

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,12 +220,12 @@
         "restructuredtext.builtDocumentationPath": {
           "type": "string",
           "default": null,
-          "description": "Sphinx HTML output folder. Defaults to 'restructuredtext.confPath'/_build/html This is an absolute path, and you can use ${workspaceRoot} to represent workspace root folder."
+          "description": "Sphinx's HTML output folder. Defaults to 'restructuredtext.confPath'/_build/html This is an absolute path, and you can use ${workspaceRoot} to represent the workspace root folder."
         },
         "restructuredtext.confPath": {
           "type": "string",
           "default": null,
-          "description": "The folder that contains conf.py. Set this if the directory is not found automatically. This is an absolute path, and you can use ${workspaceRoot} to represent workspace root folder."
+          "description": "Sphinx's configuration folder containing conf.py. Set this option if the path is not found automatically. This is an absolute path, and you can use ${workspaceRoot} to represent the workspace root folder."
         },
         "restructuredtext.updateOnTextChanged": {
           "type": "string",
@@ -240,12 +240,12 @@
         "restructuredtext.sphinxBuildPath": {
           "type": "string",
           "default": null,
-          "description": "The full path of sphinx-build utility. This is an absolute path, and you can use ${workspaceRoot} to represent workspace root folder."
+          "description": "The full path of the sphinx-build executable. This is an absolute path, and you can use ${workspaceRoot} to represent the workspace root folder."
         },
         "restructuredtext.linter.executablePath": {
           "type": "string",
           "default": null,
-          "description": "Points to the doc8 exectuable."
+          "description": "Points to the doc8 executable."
         },
         "restructuredtext.linter.run": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -219,18 +219,13 @@
         },
         "restructuredtext.builtDocumentationPath": {
           "type": "string",
-          "default": "${workspaceRoot}/_build/html",
-          "description": "HTML page output folder relative to workspace root. This is an absolute path, and you can use ${workspaceRoot} to represent workspace root folder."
+          "default": null,
+          "description": "Sphinx HTML output folder. Defaults to 'restructuredtext.confPath'/_build/html This is an absolute path, and you can use ${workspaceRoot} to represent workspace root folder."
         },
         "restructuredtext.confPath": {
           "type": "string",
-          "default": "${workspaceRoot}",
-          "description": "The folder that contains conf.py relative to workspace root. This is an absolute path, and you can use ${workspaceRoot} to represent workspace root folder."
-        },
-        "restructuredtext.confInSameOrParentDir": {
-          "type": "boolean",
-          "default": true,
-          "description": "Search for Sphinx conf.py in the same directory as the file being edited or a parent directory."
+          "default": null,
+          "description": "The folder that contains conf.py. Set this if the directory is not found automatically. This is an absolute path, and you can use ${workspaceRoot} to represent workspace root folder."
         },
         "restructuredtext.updateOnTextChanged": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -227,6 +227,11 @@
           "default": "${workspaceRoot}",
           "description": "The folder that contains conf.py relative to workspace root. This is an absolute path, and you can use ${workspaceRoot} to represent workspace root folder."
         },
+        "restructuredtext.confInSameOrParentDir": {
+          "type": "boolean",
+          "default": true,
+          "description": "Search for Sphinx conf.py in the same directory as the file being edited or a parent directory."
+        },
         "restructuredtext.updateOnTextChanged": {
           "type": "string",
           "default": "true",

--- a/package.json
+++ b/package.json
@@ -242,6 +242,11 @@
           "default": null,
           "description": "The full path of the sphinx-build executable. This is an absolute path, and you can use ${workspaceRoot} to represent the workspace root folder."
         },
+        "restructuredtext.rst2htmlCommand": {
+          "type": "string",
+          "default": null,
+          "description": "The full path of the rst2html.py executable. This is an absolute path, and you can use ${workspaceRoot} to represent the workspace root folder."
+        },
         "restructuredtext.linter.executablePath": {
           "type": "string",
           "default": null,

--- a/src/features/utils/confPyFinder.ts
+++ b/src/features/utils/confPyFinder.ts
@@ -1,0 +1,109 @@
+'use strict';
+
+import * as path from "path";
+import * as fs from "fs";
+import { workspace, window, OutputChannel, Uri } from "vscode";
+import { Configuration } from "./configuration";
+
+export class ConfPyFinder {
+    public static async findConfDir(rstPath: string, channel: OutputChannel): Promise<string> {
+        // Sanity check - the file we are previewing must exist
+        if (!fs.existsSync(rstPath) || !fs.statSync(rstPath).isFile) {
+            return Promise.reject("RST extension got invalid file name: " + rstPath);
+        }
+
+        let paths: string[] = [];
+
+        // A path may be configured
+        let confPathFromSettings = Configuration.loadSetting("confPath", null);
+        if (confPathFromSettings != null) {
+            channel.appendLine("Using Spinx conf.py path from " +
+                "restructuredtext.confPath settings: " + confPathFromSettings);
+            return Promise.resolve(confPathFromSettings);
+        }
+
+        // Add path to a directory containing conf.py if it is not already stored
+        function addPaths(pathsToAdd: string[]) {
+            pathsToAdd.forEach(confPath => {
+                let pth = path.dirname(confPath);
+                if (paths.indexOf(pth) == -1)
+                    paths.push(pth);
+            });
+        }
+
+        // Search for unique conf.py paths in the workspace and in parent
+        // directories (useful when opening a single file, not a workspace)
+        const paths1: string[] = await findConfPyFiles();
+        const paths2: string[] = findConfPyFilesInParentDirs(rstPath);
+        addPaths(paths1);
+        addPaths(paths2);
+        channel.appendLine("Found conf.py paths: " + JSON.stringify(paths));
+
+        // Default to the workspace root path if nothing was found
+        if (paths.length == 0)
+            return Promise.resolve(workspace.rootPath);
+
+        // Found only one conf.py, using that one
+        if (paths.length == 1) {
+            return Promise.resolve(paths[0]);
+        }
+
+        // Found multiple conf.py files, let the user decide
+        return window.showQuickPick(paths, {
+            matchOnDescription: true,
+            placeHolder: `Select 1 of ${paths.length} Sphinx directories`
+        });
+    }
+}
+
+/**
+ * Returns a list of conf.py files in the workspace
+ */
+function findConfPyFiles(): Thenable<string[]> {
+    if (!workspace.workspaceFolders) {
+        return Promise.resolve([]);
+    }
+
+    return workspace.findFiles(
+            /*include*/ '{**/conf.py}',
+            /*exclude*/ '{}',
+            /*maxResults*/ 100)
+        .then(urisToPaths);
+}
+
+function urisToPaths(uris: Uri[]): string[] {
+    let paths: string[] = [];
+    uris.forEach(uri => paths.push(uri.fsPath));
+    return paths;
+}
+
+/**
+ * Find conf.py files by looking at parent directories. Useful in case
+ * a single rst file is opened without a workspace
+ */
+function findConfPyFilesInParentDirs(rstPath: string): string[] {
+    let paths: string[] = [];
+
+    // Walk the directory up from the RST file directory looking for the conf.py file
+    let dirName = rstPath;
+    while (true) {
+        // Get the name of the parent directory
+        let parentDir = path.normalize(dirName + "/..");
+
+        // Check if we are at the root directory already to avoid an infinte loop
+        if (parentDir == dirName)
+            break;
+
+        // Sanity check - the parent directory must exist
+        if (!fs.existsSync(parentDir) || !fs.statSync(parentDir).isDirectory)
+            break;
+
+        // Check this directory for conf.py
+        let confPath = path.join(parentDir, "conf.py");
+        if (fs.existsSync(confPath) && fs.statSync(confPath).isFile)
+            paths.push(confPath);
+
+        dirName = parentDir;
+    }
+    return paths;
+}

--- a/src/features/utils/confPyFinder.ts
+++ b/src/features/utils/confPyFinder.ts
@@ -50,7 +50,6 @@ export class ConfPyFinder {
 
         // Found multiple conf.py files, let the user decide
         return window.showQuickPick(paths, {
-            matchOnDescription: true,
             placeHolder: `Select 1 of ${paths.length} Sphinx directories`
         });
     }

--- a/src/features/utils/configuration.ts
+++ b/src/features/utils/configuration.ts
@@ -23,7 +23,7 @@ export class Configuration {
         }
         return result;
     }
-    
+
     public static setRoot() {
         var old = workspace.getConfiguration("restructuredtext").get<string>("workspaceRoot");
         if (old.indexOf("${workspaceRoot}") > -1) {

--- a/src/features/utils/statusBar.ts
+++ b/src/features/utils/statusBar.ts
@@ -1,0 +1,40 @@
+"use strict"
+
+import { window, StatusBarItem, StatusBarAlignment, OutputChannel } from 'vscode';
+
+
+/**
+ * Status bar updates. Shows the selected RstTransformerConfig when a
+ * restructuredtext document is active. If you click on the status bar
+ * then the RstTransformerConfig is reset and you will need to select from
+ * the menu when the preview is generated next time.
+ */
+export default class RstTransformerStatus {
+    private _statusBarItem: StatusBarItem;
+    private _selectedConfig: string = "";
+
+    constructor() {
+        this._statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left);
+        this._statusBarItem.command = "restructuredtext.resetRstTransformer";
+        this._statusBarItem.tooltip = "The active rst to html transformer (click to reset)";
+    }
+
+    setConfiguration(conf: string) {
+        this._selectedConfig = conf;
+        this.update();
+    }
+
+    update() {
+        let editor = window.activeTextEditor;
+
+        if (this._selectedConfig &&
+            // editor is null for the preview window
+            (editor == null || editor.document.languageId === 'restructuredtext')) {
+            this._statusBarItem.text = this._selectedConfig;
+            this._statusBarItem.show();
+        }
+        else {
+            this._statusBarItem.hide();
+        }
+    }
+}


### PR DESCRIPTION
- [x] Find all instances of `conf.py` in the current workspace
- [x] Find all `conf.py` files in parent directories (if a ReST file is opened directly and not as a part of a workspace, fixes issue #91).
- [x] Let the user select which Sphinx directory to use if multiple such directories are found (fixes issue #10)
- [x] Remember the users choice of selected conf.py file
- [x] Fallback to plain rst2html if no Sphinx config is found (could replace pr #61 and pr #42) 
- [x] Show the current active conf.py file in the status bar