### PR TITLE
Silence configuration warning

### DIFF
--- a/src/features/utils/configuration.ts
+++ b/src/features/utils/configuration.ts
@@ -11,7 +11,7 @@ export class Configuration {
     public static loadAnySetting<T>(
         configSection: string, defaultValue: T, header: string = "restructuredtext"
     ): T {
-        return workspace.getConfiguration(header).get(configSection, defaultValue);
+        return workspace.getConfiguration(header, null).get(configSection, defaultValue);
     }
 
     public static loadSetting(
@@ -23,7 +23,7 @@ export class Configuration {
         }
         return result;
     }
-    
+
     public static setRoot() {
         var old = workspace.getConfiguration("restructuredtext").get<string>("workspaceRoot");
         if (old.indexOf("${workspaceRoot}") > -1) {


### PR DESCRIPTION
There is a warning in the debug console when starting the extension (via pressing F5 when the extension directory is open in vscode). The warning is related to accessing `python.pythonPath` (a scoped resource) without providing a resource or null.

Providing null silences the warning. It is probably harmless, but fixing it cannot hurt.