### PR TITLE
Fix live preview

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,7 +75,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<{ init
 
     vscode.workspace.onDidSaveTextDocument((document) => {
         if (isRstFile(document)) {
-            provider.update(document.uri);
+            provider.update(getPreviewUri(document.uri));
         }
     });
 
@@ -83,7 +83,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<{ init
     if (updateOnTextChanged === 'true') {
         vscode.workspace.onDidChangeTextDocument((event) => {
             if (isRstFile(event.document)) {
-                provider.update(event.document.uri);
+                provider.update(getPreviewUri(event.document.uri));
             }
         });
     }


### PR DESCRIPTION
Fixes #102 

P.S. Since this now works, you might encounter people complaining about performance from `updateOnTextChanged`, since this runs `sphinx-build` on any change with a rather small timeout... and on the data on disk, not on the unsaved changes the user has made, which makes this setting kinda pointless.