### PR TITLE
Prevents restructuredtext.confPath from being overwritten

### DIFF
--- a/src/features/rstDocumentContent.ts
+++ b/src/features/rstDocumentContent.ts
@@ -305,7 +305,9 @@ export default class RstDocumentContentProvider implements TextDocumentContentPr
 
         this._rstTransformerStatus.setConfiguration(rstTransformerConf.label);
         this._rstTransformerConfig = rstTransformerConf;
-        await Configuration.saveSetting('confPath', rstTransformerConf.confPyDirectory, resource);
+        if (!rstTransformerConf.confPyDirectoryFromSettings) {
+            await Configuration.saveSetting('confPath', rstTransformerConf.confPyDirectory, resource);
+        }
         return rstTransformerConf;
     }
 

--- a/src/features/utils/confPyFinder.ts
+++ b/src/features/utils/confPyFinder.ts
@@ -12,6 +12,7 @@ export class RstTransformerConfig implements QuickPickItem {
     public label: string;
     public description: string = 'Use Sphinx with the selected conf.py path';
     public confPyDirectory: string;
+    public confPyDirectoryFromSettings: boolean;
 }
 
 /**

--- a/src/features/utils/selector.ts
+++ b/src/features/utils/selector.ts
@@ -33,6 +33,7 @@ export class RstTransformerSelector {
             qpSettings.label = '$(gear) Sphinx: ' + pth;
             qpSettings.description += ' (from restructuredtext.confPath setting)';
             qpSettings.confPyDirectory = path.dirname(pth);
+            qpSettings.confPyDirectoryFromSettings = true;
             return qpSettings;
         }
         // Add path to a directory containing conf.py if it is not already stored
@@ -43,6 +44,7 @@ export class RstTransformerSelector {
                     const qp = new RstTransformerConfig();
                     qp.label = '$(gear) Sphinx: ' + pth;
                     qp.confPyDirectory = path.dirname(pth);
+                    qp.confPyDirectoryFromSettings = false;
                     configurations.push(qp);
                     pathStrings.push(pth);
                 }


### PR DESCRIPTION
Solution to #107 
As this is my first attempt at modifying typescript/javascript, please excuse if there is a better way to solve the problem.