### PR TITLE
Add toggle line comments support (Fix #115)

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,4 +1,7 @@
 {
+    "comments": {
+        "lineComment": ".."
+    },
     "brackets": [
         [
             "<",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -99,11 +99,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<{ init
         });
     });
 
-    vscode.languages.setLanguageConfiguration('restructuredtext', {
-        comments: {
-            lineComment: '..'
-        }
-    })
     return {
         initializationFinished: Promise.all([rstLspPromise])
             .then((promiseResult) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -99,6 +99,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<{ init
         });
     });
 
+    vscode.languages.setLanguageConfiguration('restructuredtext', {
+        comments: {
+            lineComment: '..'
+        }
+    })
     return {
         initializationFinished: Promise.all([rstLspPromise])
             .then((promiseResult) => {


### PR DESCRIPTION
This patch provides a minimal [`LanguageConfiguration`](https://code.visualstudio.com/docs/extensionAPI/vscode-api#LanguageConfiguration) to support the comment shortcut.