### PR TITLE
Fix underline width

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "restructuredtext",
-  "version": "104.0.0",
+  "version": "105.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3586,6 +3586,11 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
       }
+    },
+    "meaw": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/meaw/-/meaw-4.1.0.tgz",
+      "integrity": "sha512-MLWGEHSBeYP3QZS/PClIAMaIVk/MO2bSQFhzT4X7Rln/BQ68Ovok7DdpiUAMR2tSPdnpFoBfcJTBedmLSvVpCg=="
     },
     "mem": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.1",
     "lodash.throttle": "^4.1.1",
+    "meaw": "^4.1.0",
     "mkdirp": "^0.5.1",
     "tmp": "0.0.33",
     "vscode-languageclient": "^3.5.0",

--- a/src/features/underline.ts
+++ b/src/features/underline.ts
@@ -2,6 +2,7 @@
  * This module provides utility functions to handle underline title levels
  */
 import * as vscode from 'vscode';
+import * as meaw from 'meaw';
 
 // list of underline characters, from higher level to lower level
 // Use the recommended items from http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#sections,
@@ -57,10 +58,11 @@ export function underline(textEditor: vscode.TextEditor, edit: vscode.TextEditor
             underlineChar = currentUnderlineChar(line, nextLine);
         }
 
+        const lineWidth = underlineWidth(line);
         if (underlineChar === null) {
             edit.insert(
                 new vscode.Position(position.line, line.length),
-                '\n' + '='.repeat(line.length),
+                '\n' + '='.repeat(lineWidth),
             );
         } else {
             const nextLineRange = new vscode.Range(
@@ -68,7 +70,17 @@ export function underline(textEditor: vscode.TextEditor, edit: vscode.TextEditor
                 new vscode.Position(position.line + 1, nextLine.length),
             );
             const replacement = nextUnderlineChar(underlineChar, reverse);
-            edit.replace(nextLineRange, replacement.repeat(line.length));
+            edit.replace(nextLineRange, replacement.repeat(lineWidth));
         }
     });
+}
+
+/**
+ * Return the column width of unicode text.
+ * See https://sourceforge.net/p/docutils/code/HEAD/tree/tags/docutils-0.14/docutils/utils/__init__.py#l643
+ * 
+ * TODO: consider the count of combining chars same as docutils.
+ */
+export function underlineWidth(line: string): number {
+    return meaw.computeWidth(line.normalize());
 }


### PR DESCRIPTION
Now, this plugin create too short underlines for East Asian Characters.

Expected:

```rst
あいうえお
==========
```

Actual:

```rst
あいうえお
=====
```

`docutils` compute underline width with East Asian Width which was defined by Unicode: http://unicode.org/reports/tr11/
I fixed this issue.

P.S.

Strictly speaking, `docutils` also use "combining class" of Unicode characters at https://sourceforge.net/p/docutils/code/HEAD/tree/tags/docutils-0.14/docutils/utils/__init__.py#l643
However, I cannot find good solutions to get "combining class" in JavaScript.
Because longer underline width is not problem, I removed the logic using combining class and added normalizing, `String.prototype.normalize` helps to calculate the correct length of string including combining characters in many cases.
