### PR TITLE
Remove dependency on the pythonPath setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,9 @@
       "installTestPath": "./.rst/Server"
     }
   ],
+  "featureFlags": {
+    "usingNewInterpreterStorage": true
+  },
   "license": "SEE LICENSE IN LICENSE.txt",
   "homepage": "https://www.restructuredtext.net",
   "categories": [

--- a/src/features/utils/constants.ts
+++ b/src/features/utils/constants.ts
@@ -1,0 +1,5 @@
+"use strict";
+
+export class Constants {
+    public static readonly python = "python";
+}

--- a/src/python.ts
+++ b/src/python.ts
@@ -26,7 +26,7 @@ export class Python {
   }
 
   public async checkPython(resource: vscode.Uri, showInformation: boolean = true): Promise<boolean> {
-    const path = Configuration.getPythonPath(resource);
+    const path = await Configuration.getPythonPath(resource);
     if (path) {
       this.pythonPath = `"${path}"`;
       if (await this.getVersion()) {

--- a/src/rstEngine.ts
+++ b/src/rstEngine.ts
@@ -62,7 +62,7 @@ export class RSTEngine {
 
       let build = Configuration.getSphinxPath(uri);
       if (build == null) {
-        const python = Configuration.getPythonPath(uri);
+        const python = await Configuration.getPythonPath(uri);
         if (python) {
           build = '"' + python + '" -m sphinx';
         }


### PR DESCRIPTION
According to the announcement made by the vscode-python extension, it is not possible to use the pythonPath setting anymore.
Therefore, it is necessary to make use of the API provided by the vscode-python extension
https://github.com/microsoft/vscode-python/issues/12596

Fix #222

This fix still needs some refinement and surely some feedback. 