### PR TITLE
Add increaseIndentPattern rule to the language configuration

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -46,5 +46,9 @@
     ],
     "folding": {
         "offSide": true
+    },
+    "indentationRules": {
+        "increaseIndentPattern": "^\\.{2}\\s\\w+:{2}(\\s\\w+)?$",
+        "decreaseIndentPattern": "^\\n$"
     }
 }


### PR DESCRIPTION
Adding the increaseIndentPattern rule will indent the content after the directives are written.
![indentation](https://user-images.githubusercontent.com/10437475/97858622-18537a80-1d08-11eb-8ae5-d81081a6d3ef.gif)

