### PR TITLE
Disables resttext tab and shift+tab keybindings in snippet mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,12 +210,12 @@
       {
         "command": "resttext.key.tab",
         "key": "tab",
-        "when": "resttext.tab.enabled && editorTextFocus && !suggestWidgetVisible && editorLangId==restructuredtext"
+        "when": "resttext.tab.enabled && editorTextFocus && !inSnippetMode && !suggestWidgetVisible && editorLangId==restructuredtext"
       },
       {
         "command": "resttext.key.shift.tab",
         "key": "shift+tab",
-        "when": "resttext.shift.tab.enabled && editorTextFocus && !suggestWidgetVisible && editorLangId==restructuredtext"
+        "when": "resttext.shift.tab.enabled && editorTextFocus && !inSnippetMode && !suggestWidgetVisible && editorLangId==restructuredtext"
       }
     ],
     "commands": [
@@ -309,13 +309,13 @@
         "category": "reStructuredText",
         "command": "resttext.key.tab",
         "title": "%resttext.key.tab.title%",
-        "when": "resttext.tab.enabled && editorTextFocus && !suggestWidgetVisible && editorLangId==restructuredtext"
+        "when": "resttext.tab.enabled && editorTextFocus && !inSnippetMode && !suggestWidgetVisible && editorLangId==restructuredtext"
       },
       {
         "category": "reStructuredText",
         "command": "resttext.key.shift.tab",
         "title": "%resttext.key.shift.tab.title%",
-        "when": "resttext.shift.tab.enabled && editorTextFocus && !suggestWidgetVisible && editorLangId==restructuredtext"
+        "when": "resttext.shift.tab.enabled && editorTextFocus && !inSnippetMode && !suggestWidgetVisible && editorLangId==restructuredtext"
       }
     ],
     "menus": {


### PR DESCRIPTION
Small PR to fix a minor bug I encountered today when I inserted a snippet via suggestion while in a list and then attempted to switch between the snippet placeholders using `tab` and `shift+tab`.

VSCode did not switch the placeholders as expected but instead triggered the suggestions popup. After a short inspection with the keybinding troubleshooter, it became apparent that the [`resttext.key.tab`](https://github.com/vscode-restructuredtext/vscode-restructuredtext/blob/master/package.json#L211) and [`resttext.key.shift.tab`](https://github.com/vscode-restructuredtext/vscode-restructuredtext/blob/master/package.json#L216) keybindings were intercepting the keypresses because the editor was still in a list.

Looking at the handlers registered for these keybindings, when using `tab` or `shift+tab` in lists, the extension intercepts the keybinding and [triggers a suggestion](https://github.com/vscode-restructuredtext/vscode-restructuredtext/blob/master/src/editor/commands.ts#L499) for `tab` or [does nothing](https://github.com/vscode-restructuredtext/vscode-restructuredtext/blob/master/src/editor/commands.ts#L521) for `shift+tab`.

The changes in the PR extend the `when` clauses of the keybindings in a similar fashion to [`restructuredtext.editor.listEditing.onTabKey`](https://github.com/vscode-restructuredtext/vscode-restructuredtext/blob/master/package.json#L142) and [`restructuredtext.editor.listEditing.onShiftTabKey`](https://github.com/vscode-restructuredtext/vscode-restructuredtext/blob/master/package.json#L142), respectively, so the original functionality of the keybinding is preserved, but suppressed when the editor is currently in snippet mode, so the expected behavior of the keybindings for this situation still work.

Curiously, the `listEditing` keybindings don't seem to get triggered at all. Judging from looking at the code, they seem to be responsible for indentation/de-indentation of selected list text, but I haven't had the time to have a closer look at them.