### PR TITLE
Make "tab" keybinding compatible with other extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
       {
         "command": "restructuredtext.editor.listEditing.onTabKey",
         "key": "tab",
-        "when": "editorTextFocus && !editorReadonly && editorLangId == restructuredtext && !suggestWidgetVisible && !editorTabMovesFocus && !inSnippetMode && !hasSnippetCompletions && !hasOtherSuggestions"
+        "when": "editorTextFocus && !editorReadonly && editorLangId == restructuredtext && !suggestWidgetVisible && !editorTabMovesFocus && !inSnippetMode && !hasSnippetCompletions && !hasOtherSuggestions && !inlineSuggestionVisible"
       },
       {
         "command": "restructuredtext.editor.listEditing.onShiftTabKey",
@@ -210,7 +210,7 @@
       {
         "command": "resttext.key.tab",
         "key": "tab",
-        "when": "resttext.tab.enabled && editorTextFocus && !suggestWidgetVisible && editorLangId==restructuredtext"
+        "when": "resttext.tab.enabled && editorTextFocus && !suggestWidgetVisible && editorLangId==restructuredtext && !inlineSuggestionVisible"
       },
       {
         "command": "resttext.key.shift.tab",


### PR DESCRIPTION
I was using another extension (GitHub CoPilot) and I was finding that the tab-to-complete wasn't working with it. Similar to the diagnosis at https://github.com/yzhang-gh/vscode-markdown/issues/1011, the keybinding for this extension was taking precedence, eating the tab before CoPilot could get it. Therefore, this PR makes the keybinding more strict in when it accepts a "tab" event.

Tested on my machine, it fixes the problem as described in that issue. Not sure if this will affect other aspects of this extension?