### PR TITLE
Fix preview when "implicit" esbonio configs are used

### DIFF
--- a/src/preview/confPyFinder.ts
+++ b/src/preview/confPyFinder.ts
@@ -13,6 +13,7 @@ export class RstTransformerConfig implements QuickPickItem {
     public tooltip: string;
     public description: string = 'Use Sphinx with the selected conf.py path';
     public confPyDirectory: string;
+    public engine: string;
     public workspaceRoot: string;
 }
 

--- a/src/preview/confPyFinder.ts
+++ b/src/preview/confPyFinder.ts
@@ -27,7 +27,7 @@ export async function findConfPyFiles(resource: Uri): Promise<string[]> {
 
     const items = await workspace.findFiles(
             /*include*/ '{**/conf.py}',
-            /*exclude*/ '{}',
+            /*exclude*/ '{**/site-packages/**/conf.py}',
             /*maxResults*/ 100);
     return urisToPaths(items, resource);
 }

--- a/src/preview/confPyFinder.ts
+++ b/src/preview/confPyFinder.ts
@@ -11,7 +11,7 @@ import { QuickPickItem, Uri, workspace } from 'vscode';
 export class RstTransformerConfig implements QuickPickItem {
     public label: string;
     public tooltip: string;
-    public description: string = 'Use Sphinx with the selected conf.py path';
+    public description: string = 'Use Sphinx with this conf.py';
     public confPyDirectory: string;
     public engine: string;
     public workspaceRoot: string;

--- a/src/preview/selector.ts
+++ b/src/preview/selector.ts
@@ -27,6 +27,7 @@ export class RstTransformerSelector {
         docutils.tooltip = 'Click to reset';
         docutils.description = 'Do not use Sphinx, but docutils instead';
         docutils.confPyDirectory = '';
+        docutils.engine = 'docutils'
         docutils.workspaceRoot = workspaceRoot;
 
         if (!inReset) {
@@ -41,6 +42,7 @@ export class RstTransformerSelector {
             qpSettings.description += ' (from restructuredtext.confPath setting)';
             qpSettings.confPyDirectory = path.dirname(pth);
             qpSettings.workspaceRoot = workspaceRoot;
+            qpSettings.engine = 'sphinx';
             return qpSettings;
         }
         // Add path to a directory containing conf.py if it is not already stored
@@ -53,6 +55,7 @@ export class RstTransformerSelector {
                     qp.tooltip = `Click to reset. Full path: ${pth}`;
                     qp.confPyDirectory = path.dirname(pth);
                     qp.workspaceRoot = workspaceRoot;
+                    qp.engine = 'sphinx';
                     configurations.push(qp);
                     pathStrings.push(pth);
                 }

--- a/src/preview/selector.ts
+++ b/src/preview/selector.ts
@@ -88,5 +88,5 @@ function shrink(path: string) {
         return path;
     }
 
-    return `...${path.substring(path.length - 22)}`;
+    return `...${path.substring(path.length - 32)}`;
 }

--- a/src/preview/statusBar.ts
+++ b/src/preview/statusBar.ts
@@ -74,8 +74,16 @@ export default class RstTransformerStatus {
         }
 
         this.config = rstTransformerConf;
-        this._logger.log("[preview] set config to " + rstTransformerConf.confPyDirectory);
-        await Configuration.setConfPath(rstTransformerConf.confPyDirectory, resource, true);
+
+        if (rstTransformerConf.engine === 'docutils') {
+            this._logger.log("[preview] engine set to docutils");
+            await Configuration.setPreviewName('docutils', resource)
+        } else {
+            this._logger.log("[preview] set config to " + rstTransformerConf.confPyDirectory);
+            await Configuration.setPreviewName('sphinx', resource)
+            await Configuration.setConfPath(rstTransformerConf.confPyDirectory, resource, true);
+        }
+
         return rstTransformerConf;
     }
 }

--- a/src/test/suite/preview.test.ts
+++ b/src/test/suite/preview.test.ts
@@ -73,7 +73,7 @@ suite("Preview Tests", function() {
   test("Example 1 to HTML", async function() {
     this.timeout(30000);
     const editor = await openFile(path.join(samplePath, "docutils", "example1.rst"));
-    const val = await engine.compile(path.join(samplePath, "docutils", "example1.rst"), editor.document.uri, '', true, null);
+    const val = await engine.compile(path.join(samplePath, "docutils", "example1.rst"), editor.document.uri, true, null);
     return new Promise((res, rej) => {
       fs.readFile(
         path.join(samplePath, "docutils", "example1.html"),
@@ -96,7 +96,7 @@ suite("Preview Tests", function() {
   test("Sphinx to HTML", async function() {
     this.timeout(30000);
     const editor = await openFile(path.join(samplePath, "sphinx", "index.rst"));
-    const val = await engine.compile(path.join(samplePath, "sphinx", "index.rst"), editor.document.uri, path.join(samplePath, 'sphinx'), false, null);
+    const val = await engine.compile(path.join(samplePath, "sphinx", "index.rst"), editor.document.uri, false, null);
     return new Promise((res, rej) => {
       fs.readFile(
         path.join(samplePath, "index.html"),

--- a/src/util/configuration.ts
+++ b/src/util/configuration.ts
@@ -171,6 +171,10 @@ export class Configuration {
         return await Configuration.saveSetting('sphinx.confDir', value, resource, insertMacro, 'esbonio');
     }
 
+    public static async setPreviewName(value: string, resource: Uri = null): Promise<string> {
+        return await Configuration.saveAnySetting('preview.name', value, resource);
+    }    
+
     public static async setSphinxDisabled(resource: Uri = null) {
         await Configuration.saveAnySetting('preview.sphinx.disabled', true, resource);
     }


### PR DESCRIPTION
The esbonio language server can, in some cases, automatically discover the location of a project's `conf.py` file without requiring the `esbonio.sphinx.confDir` option to be set. 

When previewing a project that is implicitly configured like this, the vscode-restructuredtext extension should still be able to offer the Sphinx powered preview.

However, since the `RSTEngine` sources its `confPyDirectory` from the settings file rather than the esbonio client the extension incorrectly shows the docutils based preview instead.

This PR
- Reworks the `RSTEngine` to use the esbonio client to determine the directory holding the `conf.py` file, enabling the Sphinx based preview to be used with implicitly configured projects. 
 
  Rather than checking for `confPyDirectory == ''`, a docutils based preview is now shown if esbonio encounters an error, or if docutils is explicitly chosen in settings.
- Adjusts the status item used to pick the conf.py/preview method to work with the above changes
-  Makes a few other tweaks to the quickpick list used to choose the preview method, but these are contained in separate commits so easy to drop if required.