### PR TITLE
Pass shell environment though to Sphinx process (Fixes issue #404)

### DIFF
--- a/src/language-server/client.ts
+++ b/src/language-server/client.ts
@@ -210,6 +210,7 @@ export class EsbonioClient {
     command.push(await configuration.getPythonPath()); //await this.python.getCmd()
 
     let options: any = {};
+    options.shell = true;
     const sourceFolder = configuration.getEsbonioSourceFolder();
     if (sourceFolder) {
       // launch language server from source folder.


### PR DESCRIPTION
This fixes issue #404

By setting `shell=true` in the options structure, environment variables from the calling process are passed down into the `sphinx-build` process. This includes the `PYTHONPATH` variable, which allows Sphinx to find modules that are not in the default system path.