### PR TITLE
countTextWidth should not count non-ascii characters twice

### DIFF
--- a/src/editor/util.ts
+++ b/src/editor/util.ts
@@ -55,16 +55,7 @@ export function isAscii(text: string): boolean {
 }
 
 export function countTextWidth(text: string): number {
-    let count = 0;
-    for (let i = 0; i < text.length; i++) {
-        const chr = text[i];
-        if (isAscii(chr)) {
-            count += 1;
-        } else {
-            count += 2;
-        }
-    }
-    return count;
+    return text.length;
 }
 
 export function tableSizeIsSelected(


### PR DESCRIPTION
When table cells contains non-ascii characters, text-length is calculated incorrectly, resulting in shifted table:

+-----+-----+
| č  | č  |
+-----+-----+

I checked the code: There is countTextWidth() method in /editor/util.js. This method counts every non-ascii character as two for some reason. Id did not found any reason for this.

Proposed solution is to use simple str.length to calculate string length.

Related to issue #435 