### PR TITLE
fix doc8 `RuntimeWarning`

### DIFF
--- a/src/linter/extension.ts
+++ b/src/linter/extension.ts
@@ -19,7 +19,7 @@ export async function activate(
         if (doc8Path || (await python.checkDoc8Install())) {
             const doc8 = new RstLintingProvider(
                 'doc8',
-                'doc8.main',
+                'doc8',
                 doc8Path,
                 configuration.getDoc8ExtraArgs(),
                 logger,


### PR DESCRIPTION
resolves `RuntimeWarning: 'doc8.main' found in sys.modules after import of package 'doc8', but prior to execution of 'doc8.main'; this may result in unpredictable behaviour` by changing doc8 execution from "doc8.main" to "doc8".

![image](https://github.com/vscode-restructuredtext/vscode-restructuredtext/assets/23145462/f4544214-f98d-4cd5-a9da-4b47d93b02f4)

The above screenshot shows this warning being reported in `PROBLEMS`.

The warning is caused by [`doc8.__init__`](https://github.com/PyCQA/doc8/blob/main/src/doc8/__init__.py) importing `doc8.main` resulting in `python -m doc8.main` causing the import to happen twice. `python -m doc8` resolves this as [`doc8.__main__`](https://github.com/PyCQA/doc8/blob/main/src/doc8/__main__.py) implements the execution of `doc8.main` when called this way.

---

Note I was unable to get `yarn run pretest && yarn run test` to run locally so relying on GitHub actions to perform tests and show me what else needs to be updated.
