### PR TITLE
Fix No module named `rstcheck.__main__`

### DIFF
--- a/src/linter/extension.ts
+++ b/src/linter/extension.ts
@@ -36,7 +36,7 @@ export async function activate(
         if (rstcheckPath || (await python.checkRstCheckInstall())) {
             const rstcheck = new RstLintingProvider(
                 'rstcheck',
-                'rstcheck',
+                'rstcheck._cli',
                 rstcheckPath,
                 configuration.getRstCheckExtraArgs(),
                 logger,


### PR DESCRIPTION
Fixes #441 