### PR TITLE
Fix doc8 version check

### DIFF
--- a/src/util/python.ts
+++ b/src/util/python.ts
@@ -88,8 +88,9 @@ export class Python {
     public async checkDoc8Version(): Promise<string> {
         try {
             return await this.exec(
-                '-c',
-                '"import doc8; print(doc8.__version__)"'
+                '-m',
+                'doc8',
+                '--version'
             );
         } catch (e) {
             return '0.0.0';


### PR DESCRIPTION
The version check function fails on `doc8` versions older than **1.1.0**, however it seems `vscode-restructuredtext` supports versions [from **0.8.1** onwards](https://github.com/vscode-restructuredtext/vscode-restructuredtext/blob/86d19203b6e3e52ad203fed3a2adc575db232bd5/src/linter/extension.ts#L40)

This change supports version checking for newer and older versions of doc8 restoring compatibility with older versions.